### PR TITLE
Fixes Wrong offset error (IndexOutOfBoundsException)

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/foundation/KotlinSyntax.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/foundation/KotlinSyntax.kt
@@ -24,8 +24,8 @@ object KotlinSyntax {
                 PsiDiagnosticUtils.offsetToLineAndColumn(document, psi.textRange.endOffset)
 
         fun highlightByType(psi: PsiElement, type: TypeOfText) {
-            val (start, end) = positions(psi)
             try {
+                val (start, end) = positions(psi)
                 syntax.highlight(
                     inputFile.newRange(
                         start.line,


### PR DESCRIPTION
I'm getting java.lang.IndexOutOfBoundsException: Wrong offset: x. Should be in range: [0, y] in several files.

The latest version (1.3.0) doesn't help in my case.
The exception was throwing one line later at ```positions(psi)```

This PR fixes it (and should help in https://github.com/detekt/sonar-kotlin/issues/106)

I'll post a separate issue or PR with details related to the source of the exception later.