### PR TITLE
Rewrite detekt sensor test to spek

### DIFF
--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensorSpec.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/DetektSensorSpec.kt
@@ -5,8 +5,6 @@ import io.gitlab.arturbosch.detekt.sonar.foundation.PATH_FILTERS_KEY
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
 import org.sonar.api.batch.fs.internal.DefaultFileSystem
 import org.sonar.api.batch.fs.internal.DefaultInputFile
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder
@@ -14,22 +12,22 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester
 import org.sonar.api.config.internal.MapSettings
 import org.sonar.api.measures.FileLinesContext
 import org.sonar.api.measures.FileLinesContextFactory
+import org.spekframework.spek2.Spek
 import java.io.File
 
-class DetektSensorTest {
+class DetektSensorSpec : Spek({
 
-    private val resourcesDir = File(RESOURCES_PATH)
-    private val sourceDir = File(RESOURCES_PATH, KOTLIN_PATH)
-    private val settings = MapSettings().setProperty(PATH_FILTERS_KEY, KOTLIN_PATH)
+    val resourcesDir = File(RESOURCES_PATH)
+    val sourceDir = File(RESOURCES_PATH, KOTLIN_PATH)
+    val settings = MapSettings().setProperty(PATH_FILTERS_KEY, KOTLIN_PATH)
 
-    private lateinit var context: SensorContextTester
-    private lateinit var fileSystem: DefaultFileSystem
-    private lateinit var fileLinesContextFactory: FileLinesContextFactory
-    private lateinit var sensor: DetektSensor
-    private lateinit var fileLinesContext: FileLinesContext
+    lateinit var context: SensorContextTester
+    lateinit var fileSystem: DefaultFileSystem
+    lateinit var fileLinesContextFactory: FileLinesContextFactory
+    lateinit var sensor: DetektSensor
+    lateinit var fileLinesContext: FileLinesContext
 
-    @Before
-    fun setUp() {
+    beforeEachTest {
         // Recreating all mutable objects to avoid retaining states across tests
         context = SensorContextTester.create(resourcesDir.absoluteFile).setSettings(settings)
         fileSystem = context.fileSystem()
@@ -41,17 +39,7 @@ class DetektSensorTest {
         every { fileLinesContextFactory.createFor(any()) } returns fileLinesContext
     }
 
-    @Test
-    fun `executes detekt`() {
-        val file = addMockFile("KotlinFile.kt")
-
-        sensor.execute(context)
-        val issues = context.allIssues().filter { it.primaryLocation().inputComponent() == file }
-
-        assertThat(issues).hasSize(7)
-    }
-
-    private fun addMockFile(filePath: String): DefaultInputFile {
+    fun addMockFile(filePath: String): DefaultInputFile {
         val sourceFile = File(sourceDir, filePath)
         val kotlinFile = TestInputFileBuilder(RESOURCES_PATH, "$KOTLIN_PATH/$filePath")
             .setLanguage(LANGUAGE_KEY)
@@ -60,6 +48,16 @@ class DetektSensorTest {
         fileSystem.add(kotlinFile)
         return kotlinFile
     }
+
+    test("executes detekt") {
+        val file = addMockFile("KotlinFile.kt")
+
+        sensor.execute(context)
+        val issues = context.allIssues().filter { it.primaryLocation().inputComponent() == file }
+
+        assertThat(issues).hasSize(7)
+    }
+}) {
 
     companion object {
         const val RESOURCES_PATH = "src/test/resources"


### PR DESCRIPTION
We only configured spek as a test runner.
All junit5 tests were not executed at all.