### PR TITLE
Prepare release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Detekt - Changelog
 
+#### 2.4.0 - 2021-10-31
+
+##### Changelog
+
+- Based on detekt 1.18.1
+- Fixed definition of prop `inputPaths` using sonar.sources
+- Fixed usage of `Path` for Java 8
+
+##### Dependencies Update
+
+- Sonar API to 9.1.0.47736
+- Kotlin to 1.5.31
+- AssertJ to 3.21.0
+- JCommander to 1.81
+- Tested on CI against Java 16
+
 #### 2.3.0 - 2020-09-26
 
 - Based on detekt 1.14.1

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.detekt</groupId>
     <artifactId>sonar-detekt</artifactId>
-    <version>2.3.0</version>
+    <version>2.4.0</version>
     <url>https://github.com/detekt/sonar-kotlin</url>
 
     <licenses>
@@ -19,12 +19,12 @@
     <packaging>sonar-plugin</packaging>
 
     <properties>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
         <spek.version>2.0.17</spek.version>
         <detekt.version>1.18.1</detekt.version>
-        <sonar.api.version>8.9.2.46101</sonar.api.version>
-        <assertj.version>3.20.2</assertj.version>
-        <jcommander.version>1.78</jcommander.version>
+        <sonar.api.version>9.1.0.47736</sonar.api.version>
+        <assertj.version>3.21.0</assertj.version>
+        <jcommander.version>1.81</jcommander.version>
         <mockk.version>1.12.0</mockk.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
-                <version>1.19.0.397</version>
+                <version>1.20.0.405</version>
                 <extensions>true</extensions>
                 <configuration>
                     <pluginKey>detekt</pluginKey>
@@ -164,7 +164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>
@@ -230,7 +230,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8.1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Time to bake a new release 🎉 

I've also bumped the following deps:
- Sonar API to 9.1.0.47736
- Kotlin to 1.5.31
- AssertJ to 3.21.0
- JCommander to 1.81

Tested locally with `mvn clean install verify` and all is green 👍 