### PR TITLE
Prepare release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Detekt - Changelog
 
+#### 2.5.0 - 2022-01-09
+
+##### Changelog
+
+- Based on detekt 1.19.0
+- Configured `sonarQubeMinVersion` to 8.9
+
+##### Dependencies Update
+
+- Kotlin to 1.6.10
+
 #### 2.4.0 - 2021-10-31
 
 ##### Changelog

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - Integrates [detekt](https://github.com/detekt/detekt) for static code analysis
 - Default quality profiles `detekt active` (80+ rules) and `detekt all` (164+ rules)
-- Supports SonarQube 7.9.3+
+- Supports SonarQube 8.9+
 - Supports detekt's `yaml config`, `baseline.xml` and `excludes`
 - Seamless integration with official SonarKotlin (no redundant features)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.detekt</groupId>
     <artifactId>sonar-detekt</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <url>https://github.com/detekt/sonar-kotlin</url>
 
     <licenses>
@@ -19,9 +19,9 @@
     <packaging>sonar-plugin</packaging>
 
     <properties>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
         <spek.version>2.0.17</spek.version>
-        <detekt.version>1.18.1</detekt.version>
+        <detekt.version>1.19.0</detekt.version>
         <sonar.api.version>9.1.0.47736</sonar.api.version>
         <assertj.version>3.21.0</assertj.version>
         <jcommander.version>1.81</jcommander.version>
@@ -57,6 +57,11 @@
         <dependency>
             <groupId>io.gitlab.arturbosch.detekt</groupId>
             <artifactId>detekt-formatting</artifactId>
+            <version>${detekt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gitlab.arturbosch.detekt</groupId>
+            <artifactId>detekt-api</artifactId>
             <version>${detekt.version}</version>
         </dependency>
         <dependency>
@@ -127,6 +132,7 @@
                     <pluginIssueTrackerUrl>https://github.com/detekt/sonar-kotlin/issues</pluginIssueTrackerUrl>
                     <pluginOrganizationName>detekt Team</pluginOrganizationName>
                     <pluginOrganizationUrl>https://github.com/detekt</pluginOrganizationUrl>
+                    <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
                 </configuration>
             </plugin>
             <plugin>
@@ -214,7 +220,7 @@
             <plugin>
                 <groupId>com.github.ozsie</groupId>
                 <artifactId>detekt-maven-plugin</artifactId>
-                <version>1.18.1.1</version>
+                <version>1.19.0</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.sonar.rules
 
 import io.github.detekt.tooling.api.DefaultConfigurationProvider
+import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
-import io.gitlab.arturbosch.detekt.api.internal.BaseRule
 import io.gitlab.arturbosch.detekt.sonar.foundation.REPOSITORY_KEY
 import org.sonar.api.rule.RuleKey
 import java.util.ServiceLoader


### PR DESCRIPTION
Time to bake a new release 🎉 This will be based on Detekt 1.19.x

I've also bumped the following deps:
- Kotlin to 1.6.10

Plus I've specified `sonarQubeMinVersion` to fix #152

Tested locally with `mvn clean install verify` and all is green 👍 

Fixes #152