### PR TITLE
Update Detekt to v1.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
     <packaging>sonar-plugin</packaging>
 
     <properties>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.8.21</kotlin.version>
         <spek.version>2.0.17</spek.version>
-        <detekt.version>1.19.0</detekt.version>
+        <detekt.version>1.23.0</detekt.version>
         <sonar.api.version>9.1.0.47736</sonar.api.version>
         <assertj.version>3.21.0</assertj.version>
         <jcommander.version>1.81</jcommander.version>

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRuleKey.kt
@@ -1,17 +1,20 @@
 package io.gitlab.arturbosch.detekt.sonar.rules
 
 import io.github.detekt.tooling.api.DefaultConfigurationProvider
+import io.github.detekt.tooling.dsl.ExtensionsSpecBuilder
 import io.gitlab.arturbosch.detekt.api.BaseRule
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.MultiRule
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.sonar.foundation.REPOSITORY_KEY
 import org.sonar.api.rule.RuleKey
 import java.util.ServiceLoader
 
-internal val defaultConfig: Config = DefaultConfigurationProvider.load().get()
+internal val extensionSpec = ExtensionsSpecBuilder()
+    .build()
+
+internal val defaultConfig: Config = DefaultConfigurationProvider.load(extensionSpec).get()
 
 /**
  * Exclude similar or duplicated rule implementations from other rule sets than the default one.
@@ -29,7 +32,6 @@ internal val allLoadedRules: List<Rule> =
     ServiceLoader.load(RuleSetProvider::class.java, Config::class.java.classLoader)
         .asSequence()
         .flatMap { loadRules(it).asSequence() }
-        .flatMap { (it as? MultiRule)?.rules?.asSequence() ?: sequenceOf(it) }
         .filterIsInstance<Rule>()
         .filterNot { it.ruleId in excludedDuplicates }
         .toList()

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRulesDefinition.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRulesDefinition.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.sonar.foundation.REPOSITORY_KEY
 import io.gitlab.arturbosch.detekt.sonar.foundation.LANGUAGE_KEY
 import org.sonar.api.rule.RuleStatus
 import org.sonar.api.server.rule.RulesDefinition
+import java.util.*
 
 class DetektRulesDefinition : RulesDefinition {
 
@@ -27,7 +28,7 @@ private fun RulesDefinition.NewRepository.defineRule(rule: Rule) {
     checkNotNull(severity) { "Unexpected severity '${rule.issue.severity}' for rule '${rule.ruleId}'." }
     val newRule = createRule(rule.ruleId).setName(rule.ruleId)
         .setHtmlDescription(description)
-        .setTags(rule.issue.severity.name.toLowerCase())
+        .setTags(rule.issue.severity.name.lowercase(Locale.getDefault()))
         .setStatus(RuleStatus.READY)
         .setSeverity(severity)
     newRule.setDebtRemediationFunction(

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRulesDefinition.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/rules/DetektRulesDefinition.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.sonar.foundation.REPOSITORY_KEY
 import io.gitlab.arturbosch.detekt.sonar.foundation.LANGUAGE_KEY
 import org.sonar.api.rule.RuleStatus
 import org.sonar.api.server.rule.RulesDefinition
-import java.util.*
+import java.util.Locale
 
 class DetektRulesDefinition : RulesDefinition {
 

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/IssueReporter.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/sensor/IssueReporter.kt
@@ -32,7 +32,7 @@ class IssueReporter(
             logger.info("Invalid location for ${issue.compactWithSignature()}.")
             return
         }
-        val pathOfIssue = baseDir.resolveSibling(issue.location.file)
+        val pathOfIssue = baseDir.resolveSibling(issue.location.filePath.absolutePath.toString())
         val inputFile = fileSystem.inputFile(fileSystem.predicates().`is`(pathOfIssue))
         if (inputFile != null) {
             ruleKeyLookup[issue.id]?.let {
@@ -42,7 +42,7 @@ class IssueReporter(
                 newIssue.save()
             } ?: logger.warn("Could not find rule key for detekt rule ${issue.id} (${issue.compactWithSignature()}).")
         } else {
-            logger.info("No file found for ${issue.location.file}")
+            logger.info("No file found for ${issue.location.filePath.absolutePath.toString()}")
         }
     }
 


### PR DESCRIPTION
Bumped the integrated Detekt version from 1.19.0 to 1.23.0
This also required a Kotlin version update, which I have done too.